### PR TITLE
Feat: Implement Pay Service

### DIFF
--- a/src/main/java/psam1017/study/java/strategy/application/PaymentUseCase.java
+++ b/src/main/java/psam1017/study/java/strategy/application/PaymentUseCase.java
@@ -1,0 +1,21 @@
+package psam1017.study.java.strategy.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import psam1017.study.java.strategy.domain.*;
+import psam1017.study.java.strategy.domain.strategy.PaymentStrategy;
+import psam1017.study.java.strategy.domain.strategy.PaymentStrategySelector;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentUseCase {
+
+    private final PaymentService paymentService;
+    private final PaymentStrategySelector strategySelector;
+
+    public Long executePayment(PaymentCommand command) {
+        PaymentStrategy strategy = strategySelector.select(command.paymentMethod());
+        Payment payment = strategy.createPayment(command);
+        return paymentService.save(payment);
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/BankTransferPayment.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/BankTransferPayment.java
@@ -1,0 +1,26 @@
+package psam1017.study.java.strategy.domain;
+
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@DiscriminatorValue("BANK_TRANSFER")
+@Entity
+public class BankTransferPayment extends Payment {
+
+    private String bankName;
+    private String accountNumber;
+
+    @Builder
+    protected BankTransferPayment(Long userId, int amount, String bankName, String accountNumber) {
+        super(userId, amount);
+        this.bankName = bankName;
+        this.accountNumber = accountNumber;
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/CreditCardPayment.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/CreditCardPayment.java
@@ -1,0 +1,28 @@
+package psam1017.study.java.strategy.domain;
+
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@DiscriminatorValue("CREDIT_CARD")
+@Entity
+public class CreditCardPayment extends Payment {
+
+    private String cardNumber;
+    private String cardHolderName;
+    private String approvalCode;
+
+    @Builder
+    protected CreditCardPayment(Long userId, int amount, String cardNumber, String cardHolderName, String approvalCode) {
+        super(userId, amount);
+        this.cardNumber = cardNumber;
+        this.cardHolderName = cardHolderName;
+        this.approvalCode = approvalCode;
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/Payment.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/Payment.java
@@ -1,0 +1,28 @@
+package psam1017.study.java.strategy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "payment_method")
+@Entity
+public abstract class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long userId;
+    private int amount;
+
+    @Column(name = "payment_method", insertable = false, updatable = false)
+    private String paymentMethod;
+
+    protected Payment(Long userId, int amount) {
+        this.userId = userId;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/PaymentCommand.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/PaymentCommand.java
@@ -1,0 +1,10 @@
+package psam1017.study.java.strategy.domain;
+
+public record PaymentCommand(
+        Long userId,
+        int amount,
+        String paymentMethod,
+        String paymentInfo
+) {
+
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/PaymentService.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/PaymentService.java
@@ -1,0 +1,18 @@
+package psam1017.study.java.strategy.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import psam1017.study.java.strategy.domain.repository.PaymentRepository;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    public Long save(Payment payment) {
+        return paymentRepository.save(payment).getId();
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/PaypalPayment.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/PaypalPayment.java
@@ -1,0 +1,26 @@
+package psam1017.study.java.strategy.domain;
+
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@DiscriminatorValue("PAYPAL")
+@Entity
+public class PaypalPayment extends Payment {
+
+    private String paypalAccount;
+    private String transactionId;
+
+    @Builder
+    protected PaypalPayment(Long userId, int amount, String paypalAccount, String transactionId) {
+        super(userId, amount);
+        this.paypalAccount = paypalAccount;
+        this.transactionId = transactionId;
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/repository/PaymentRepository.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package psam1017.study.java.strategy.domain.repository;
+
+import psam1017.study.java.strategy.domain.Payment;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/strategy/BankTransferStrategy.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/strategy/BankTransferStrategy.java
@@ -1,0 +1,29 @@
+package psam1017.study.java.strategy.domain.strategy;
+
+import org.springframework.stereotype.Component;
+import psam1017.study.java.strategy.domain.BankTransferPayment;
+import psam1017.study.java.strategy.domain.Payment;
+import psam1017.study.java.strategy.domain.PaymentCommand;
+
+@Component
+public class BankTransferStrategy implements PaymentStrategy {
+
+    @Override
+    public String getMethodName() {
+        return "BANK_TRANSFER";
+    }
+
+    @Override
+    public Payment createPayment(PaymentCommand command) {
+        // paymentInfo 예: "우리은행|123-456-7890"
+        String[] tokens = command.paymentInfo().split("\\|");
+        String bankName = tokens[0];
+        String accountNumber = tokens[1];
+        return BankTransferPayment.builder()
+                .userId(command.userId())
+                .amount(command.amount())
+                .bankName(bankName)
+                .accountNumber(accountNumber)
+                .build();
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/strategy/CreditCardStrategy.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/strategy/CreditCardStrategy.java
@@ -1,0 +1,31 @@
+package psam1017.study.java.strategy.domain.strategy;
+
+import org.springframework.stereotype.Component;
+import psam1017.study.java.strategy.domain.CreditCardPayment;
+import psam1017.study.java.strategy.domain.Payment;
+import psam1017.study.java.strategy.domain.PaymentCommand;
+
+@Component
+public class CreditCardStrategy implements PaymentStrategy {
+
+    @Override
+    public String getMethodName() {
+        return "CREDIT_CARD";
+    }
+
+    @Override
+    public Payment createPayment(PaymentCommand command) {
+        // paymentInfo 예: "1111-2222-3333-4444|홍길동|승인코드123"
+        String[] tokens = command.paymentInfo().split("\\|");
+        String cardNumber = tokens[0];
+        String cardHolderName = tokens[1];
+        String approvalCode = tokens[2];
+        return CreditCardPayment.builder()
+                .userId(command.userId())
+                .amount(command.amount())
+                .cardNumber(cardNumber)
+                .cardHolderName(cardHolderName)
+                .approvalCode(approvalCode)
+                .build();
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/strategy/PaymentStrategy.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/strategy/PaymentStrategy.java
@@ -1,0 +1,10 @@
+package psam1017.study.java.strategy.domain.strategy;
+
+import psam1017.study.java.strategy.domain.Payment;
+import psam1017.study.java.strategy.domain.PaymentCommand;
+
+public interface PaymentStrategy {
+
+    String getMethodName();
+    Payment createPayment(PaymentCommand command);
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/strategy/PaymentStrategySelector.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/strategy/PaymentStrategySelector.java
@@ -1,0 +1,32 @@
+package psam1017.study.java.strategy.domain.strategy;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentStrategySelector {
+
+    private final List<PaymentStrategy> strategies;
+    private final Map<String, PaymentStrategy> strategyMap = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        for (PaymentStrategy strategy : strategies) {
+            strategyMap.put(strategy.getMethodName().toUpperCase(), strategy);
+        }
+    }
+
+    public PaymentStrategy select(String method) {
+        PaymentStrategy found = strategyMap.get(method.toUpperCase());
+        if (found == null) {
+            throw new IllegalArgumentException("지원하지 않는 결제 방식: " + method);
+        }
+        return found;
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/domain/strategy/PaypalStrategy.java
+++ b/src/main/java/psam1017/study/java/strategy/domain/strategy/PaypalStrategy.java
@@ -1,0 +1,29 @@
+package psam1017.study.java.strategy.domain.strategy;
+
+import org.springframework.stereotype.Component;
+import psam1017.study.java.strategy.domain.Payment;
+import psam1017.study.java.strategy.domain.PaymentCommand;
+import psam1017.study.java.strategy.domain.PaypalPayment;
+
+@Component
+public class PaypalStrategy implements PaymentStrategy {
+
+    @Override
+    public String getMethodName() {
+        return "PAYPAL";
+    }
+
+    @Override
+    public Payment createPayment(PaymentCommand command) {
+        // paymentInfo 예: "test@paypal.com|txn_abc123"
+        String[] tokens = command.paymentInfo().split("\\|");
+        String paypalAccount = tokens[0];
+        String transactionId = tokens[1];
+        return PaypalPayment.builder()
+                .userId(command.userId())
+                .amount(command.amount())
+                .paypalAccount(paypalAccount)
+                .transactionId(transactionId)
+                .build();
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/infrastructure/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/psam1017/study/java/strategy/infrastructure/repository/PaymentRepositoryImpl.java
@@ -1,0 +1,21 @@
+package psam1017.study.java.strategy.infrastructure.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import psam1017.study.java.strategy.domain.Payment;
+import psam1017.study.java.strategy.domain.repository.PaymentRepository;
+import psam1017.study.java.strategy.infrastructure.repository.jpa.PaymentJpaRepository;
+
+@RequiredArgsConstructor
+@Transactional
+@Repository
+public class PaymentRepositoryImpl implements PaymentRepository {
+
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        return paymentJpaRepository.save(payment);
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/infrastructure/repository/jpa/PaymentJpaRepository.java
+++ b/src/main/java/psam1017/study/java/strategy/infrastructure/repository/jpa/PaymentJpaRepository.java
@@ -1,0 +1,7 @@
+package psam1017.study.java.strategy.infrastructure.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import psam1017.study.java.strategy.domain.Payment;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/psam1017/study/java/strategy/presentation/PayController.java
+++ b/src/main/java/psam1017/study/java/strategy/presentation/PayController.java
@@ -1,0 +1,25 @@
+package psam1017.study.java.strategy.presentation;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import psam1017.study.java.strategy.application.PaymentUseCase;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/payments")
+public class PayController {
+
+    private final PaymentUseCase paymentUseCase;
+
+    /**
+     * 결제 요청 (카드, 페이팔, 은행이체 등 다양한 결제 전략 활용)
+     */
+    @PostMapping
+    public Long pay(@RequestBody PaymentRequest request) {
+        return paymentUseCase.executePayment(request.toCommand());
+    }
+}

--- a/src/main/java/psam1017/study/java/strategy/presentation/PaymentRequest.java
+++ b/src/main/java/psam1017/study/java/strategy/presentation/PaymentRequest.java
@@ -1,0 +1,15 @@
+package psam1017.study.java.strategy.presentation;
+
+import psam1017.study.java.strategy.domain.PaymentCommand;
+
+public record PaymentRequest(
+        Long userId,
+        int amount,
+        String paymentMethod,
+        String paymentInfo
+) {
+
+    public PaymentCommand toCommand() {
+        return new PaymentCommand(userId(), amount(), paymentMethod(), paymentInfo());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# h2 db
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.hikari.username=sa
+spring.datasource.hikari.password=


### PR DESCRIPTION
### 리뷰에 앞서

Strategy 패턴(전략 패턴)은 어떤 작업을 수행하는 여러 알고리즘(또는 행위)을 각기 별도의 클래스로 캡슐화하고, 상황에 따라 쉽게 교체하여 사용할 수 있도록 하는 디자인 패턴입니다. 이를 위해 유사한 행위들을 캡슐화하는 인터페이스를 정의하고, 다형성을 활용하여 여러 전략을 확장할 수 있게 됩니다.

![image](https://github.com/user-attachments/assets/48466966-d6f4-41ca-8239-fb062e9ec7eb)

UseCase 클래스는 StrategySelector, Strategy, Service 를 호출합니다.
  - StrategySelector 는 결제수단을 해석하고 적절한 Strategy 를 찾아줍니다.
  - Strategy 는 결제수단에 따라 적절한 Payment 엔티티의 상속 엔티티를 반환합니다.
  - Service 를 이 엔티티를 Repository 로 저장하고 있습니다.
    - 반환되는 Payment 의 상속 엔티티는 Payment 와 상속 관계이므로 PaymentRepository 하나만 있어도 JPA 가 알아서 저장해줍니다.

### 리뷰 포인트

- PaymentStrategy 인터페이스를 구현하는 BankTransferStrategy, PaypalStrategy, CreditCardStrategy 를 생성했습니다. **기초적인 전략 패턴**은 잘 적용이 되었을까요?
- 이 과정에서 **OCP 를 지키지 못 한 코드**가 있을까요?
- [Controller] -> [UseCase] -> [Service] 순서로 호출하는 구조입니다. Service 에 각 Strategy 구현체를 넘기지 않고 **UseCase 에서 호출한 그 결과를 Service 에 넘기고 있는데** 적절한 전략 패턴 사례가 되고 있는지 의견을 듣고 싶습니다.
- 도메인에 PaymentStrategy 라는 디자인 패턴의 이름을 사용한 게 마음에 걸립니다. **패턴의 이름이 아니라 도메인에 적합한 이름**을 쓰면 좋았을 것 같은데 다른 추천할 만한 네이밍이 있을까요?
- 새로운 전략(Strategy) 구현체가 추가되더라도 기존의 코드에 변경이 생기지 않도록(OCP) 하고 싶어서 PaymentStrategySelector 를 만들고 **Map 을 활용하여 전략 객체들을 관리**하고 있습니다. 혹은 OCP 에서는 좀 아쉬워도 이 **전략들을 Enum 으로 관리**하는 것도 나쁘지는 않을 것 같은데, 둘 중에 어떤 걸 더 선호하시나요?
- **패키지 구조**적으로 아쉬운 부분은 없을까요?

![image](https://github.com/user-attachments/assets/9b686451-b2f2-4628-9527-010075979878)

  
  ### 바로가기

- [PaymentStrategy.java](https://github.com/psam1017/strata-pay/pull/1/files#diff-52b35a8c7b9465ad2659407188e35d2422d457ae336df63cdd6eaf11e0b6dfb7)
- [PaymentStrategySelector.java](https://github.com/psam1017/strata-pay/pull/1/files#diff-f78e37a2f2054bc2551b191617617850e0b99189e414b6a0b8840ac372bae780)
- [PaymentUseCase.java](https://github.com/psam1017/strata-pay/pull/1/files#diff-d24940ccda14978357f7a163b1cf98025eabe3a24bae8400123c5218d9df1d90)